### PR TITLE
[WFP-5825] Fixed GKE search to correctly use the right parts

### DIFF
--- a/datasources/google-compute-network.yaml
+++ b/datasources/google-compute-network.yaml
@@ -21,9 +21,12 @@ spec:
         }
 
         locals {
-          desired_labels = var.resource_tags
+          desired_labels = var.resource_tags != null ? var.resource_tags : {}
           all_networks = [for asset in data.google_cloud_asset_search_all_resources.networks.results : {
-            name   = regex("networks/([^/]+)$", asset.name)[0]
+            # Example asset.name:
+            # //compute.googleapis.com/projects/PROJECT/global/networks/NETWORK
+            # Extract the last segment as the network name
+            name   = element(split("/", asset.name), length(split("/", asset.name)) - 1)
             labels = try(asset.labels, {})
           }]
 

--- a/datasources/google-compute-subnetwork.yaml
+++ b/datasources/google-compute-subnetwork.yaml
@@ -21,10 +21,13 @@ spec:
         }
 
         locals {
-          desired_labels = var.resource_tags
+          desired_labels = var.resource_tags != null ? var.resource_tags : {}
           all_subnetworks = [for asset in data.google_cloud_asset_search_all_resources.subnetworks.results : {
-            name   = regex("subnetworks/([^/]+)$", asset.name)[0]
-            region = regex("/regions/([^/]+)/subnetworks/", asset.name)[0]
+            # Example asset.name:
+            # //compute.googleapis.com/projects/PROJECT/regions/REGION/subnetworks/SUBNETWORK
+            # Extract the last segment as the subnetwork name and the element after "regions" as the region
+            name   = element(split("/", asset.name), length(split("/", asset.name)) - 1)
+            region = element(split("/", asset.name), index(split("/", asset.name), "regions") + 1)
             labels = try(asset.labels, {})
           }]
 

--- a/datasources/google-gke.yaml
+++ b/datasources/google-gke.yaml
@@ -22,10 +22,13 @@ spec:
 
         # Parse cluster information from asset inventory results
         locals {
-          desired_labels = var.resource_tags
+          desired_labels = var.resource_tags != null ? var.resource_tags : {}
           all_clusters = [for asset in data.google_cloud_asset_search_all_resources.gke_clusters.results : {
-            name     = split("/", asset.name)[5]  # Extract cluster name from full resource name
-            location = split("/", asset.name)[3]  # Extract location from full resource name
+            # Example asset.name:
+            # //container.googleapis.com/projects/PROJECT/locations/LOCATION/clusters/CLUSTER
+            # Extract the last segment as the cluster name and the element after "locations" as the location
+            name     = element(split("/", asset.name), length(split("/", asset.name)) - 1)
+            location = element(split("/", asset.name), index(split("/", asset.name), "locations") + 1)
             labels   = try(asset.labels, {})
             asset    = asset
           }]
@@ -53,12 +56,20 @@ spec:
         # Expect identifiers: name and location
         data "google_container_cluster" "result" {
           name     = var.name
-          location = data.google_client_config.current.region
+          location = var.location
           project  = data.google_client_config.current.project
         }
 
         output "endpoint" {
           value = data.google_container_cluster.result.endpoint
+        }
+
+        output "name" {
+          value = data.google_container_cluster.result.name
+        }
+
+        output "location" {
+          value = var.location
         }
 
         output "release_channel" {


### PR DESCRIPTION
New cloudresourcesearch output:
```
14:56 $ wf search cloudresource --data-source google-gke --cloud-access gcp-devtest --region europe-west2
◉ Creating CloudResourceSearch search-google-gke-1758808654295906000
✔ CloudResourceSearch created
◉ Initialising cloud search......
✔ Cloud search initialised
◉ Preparing cloud search
✔ Cloud search prepared
◉ Running cloud search.....
✔ Cloud search completed
- identifiers:
    location: europe-west2
    name: lmgke
```

But also:
```
15:44 $  wf search cloudresource --data-source google-compute-subnetwork --cloud-access gcp-devtest --region europe-west2 --filter region=europe-west2
◉ Creating CloudResourceSearch search-google-compute-subnetwork-1758811465332841000
✔ CloudResourceSearch created
◉ Initialising cloud search......
✔ Cloud search initialised
◉ Preparing cloud search
✔ Cloud search prepared
◉ Running cloud search
✔ Cloud search completed

- identifiers:
    name: adam-compute
    region: europe-west2
- identifiers:
    name: default
    region: europe-west2
```

and
```
◉ Creating CloudResourceSearch search-google-compute-network-1758811341012913000
✔ CloudResourceSearch created
◉ Initialising cloud search......
✔ Cloud search initialised
◉ Preparing cloud search
✔ Cloud search prepared
◉ Running cloud search
✔ Cloud search completed

- identifiers:
    name: wayfinder-adam
- identifiers:
    name: demonet1
- identifiers:
    name: default
```